### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/switches/keywords.txt
+++ b/switches/keywords.txt
@@ -12,9 +12,9 @@ Switches	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-isSwitchOn   KEYWORD2
-setDelegate  KEYWORD2
-pollSwitches KEYWORD2
+isSwitchOn	KEYWORD2
+setDelegate	KEYWORD2
+pollSwitches	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords